### PR TITLE
replace username spaces with hyphen

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -43,7 +43,7 @@ socket.on('load game', function(state) {
 
 $( "button[name='join']" ).click(function() {
   console.log("submitted form");
-  username = $("input[name='user-name']").val();
+  username = $("input[name='user-name']").val().replace(/ /g, "-");
   userColor = $("select[name='user-color']").val();
   console.log(username, userColor);
   socket.emit('log on', username, userColor);


### PR DESCRIPTION
This fixes jQuery selector unrecognized expression errors and empty ID selector results caused when a username has spaces.

Since `username` is used for ID selectors, it should be formatted properly. Google recommends hyphens: https://google.github.io/styleguide/htmlcssguide.xml#ID_and_Class_Name_Delimiters
